### PR TITLE
Added support for senstive output

### DIFF
--- a/terraform-outputs/task.ts
+++ b/terraform-outputs/task.ts
@@ -43,7 +43,7 @@ export class terraformoutputstask {
 
                 console.log("- " + variableName);
 
-                tl.setVariable(variableName, variableValue);
+                tl.setVariable(variableName, variableValue, outputs[output].sensitive === true);
             }
         }
     }

--- a/tests/assertions/validations.ps1
+++ b/tests/assertions/validations.ps1
@@ -1,8 +1,20 @@
 param(
     [string]$resourcegroupname = $(throw "-resourcegroupname is required."),
-    [string]$expectedvalue = $(throw "-expectedvalue is required.")
+    [string]$resourcegroupnameexpectedvalue = $(throw "-resourcegroupname is required.")
+    [string]$containerregistryadminusername = $(throw "-containerregistryadminusername is required."),
+    [string]$containerregistryadminusernameexpectedvalue = $(throw "-containerregistryadminusernameexpectedvalue is required.")
+    [string]$containerregistryadminpassword = $(throw "-containerregistryadminpassword is required."),
+    [string]$containerregistryadminpasswordexpectedvalue = $(throw "-containerregistryadminpasswordexpectedvalue is required.")
 )
 
-If ($resourcegroupname -ne $expectedvalue) {
+If ($resourcegroupname -ne $resourcegroupnameexpectedvalue) {
+    throw
+}
+
+If ($containerregistryadminusername -ne $containerregistryadminusernameexpectedvalue) {
+    throw
+}
+
+If ($containerregistryadminpassword -ne $containerregistryadminpasswordexpectedvalue) {
     throw
 }

--- a/tests/containerregistry.tf
+++ b/tests/containerregistry.tf
@@ -1,0 +1,17 @@
+resource "azurerm_container_registry" "containerregistry" {
+  name                = "${var.PREFIX} container registry"
+  resource_group_name = "${azurerm_resource_group.resourcegroup.name}"
+  location            = "${var.AZURE_REGION}"
+  sku                 = "basic"
+  admin_enabled       = true
+}
+
+output "container_registry_admin_username" {
+  value     = "${azurerm_container_registry.containerregistry.admin_username}"
+  sensitive = true
+}
+
+output "container_registry_admin_password" {
+  value     = "${azurerm_container_registry.containerregistry.admin_password}"
+  sensitive = true
+}


### PR DESCRIPTION
Been using Terraform-Outputs for one of our projects and noticed that our sensitive variables would show up in the logs. Passing the "isSecret" to the "setVariable" method will make sure that the sensitive variable is redacted from the logs.

I wrote some test, but was unable to run them locally. You might want to double check and edit your release pipeline to match these new tests.